### PR TITLE
Fix format error

### DIFF
--- a/takeover.py
+++ b/takeover.py
@@ -44,7 +44,7 @@ k_ = {
 
 # index/lenght * 100
 def PERCENT(x, y):
-    return lambda x, y: float(x) / float(y) * 100
+    return (float(x) / float(y)) * 100 if y != 0 else 0
 
 
 services = {


### PR DESCRIPTION
Fix the `PERCENT` function so that it returns a numeric value directly instead of a lambda function. This change makes `PERCENT` calculate and return a floating-point value directly, avoiding the creation of an unnecessary lambda function. This change fixes issue #2.